### PR TITLE
fixed 5000 port forwarding

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,8 @@ services:
         image: openag/rpi_brain
         expose:
             - 5000
+        ports:
+            - 5000:5000
         devices:
             - "/dev/ttyACM0:/dev/ttyACM0"
         command: ~/catkin_ws/devel/env.sh rosrun openag_brain main -D http://db:5984 -A http://brain:5000 -f default --screen


### PR DESCRIPTION
5000 port forwarding was not configured from docker container to local machine. Due to this OpenAg UI was not able to communicate to any openag_brain api
