### PR TITLE
Limit log file sizes and roll over logs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,11 @@ services:
         depends_on:
             - db
         restart: unless-stopped
+        logging:
+            driver: "json-file"
+            options:
+                max-size: "50m"
+                max-file: 5
     db:
         image: dogi/rpi-couchdb
         expose:
@@ -17,3 +22,8 @@ services:
         ports:
             - 5984:5984
         restart: unless-stopped
+        logging:
+            driver: "json-file"
+            options:
+                max-size: "50m"
+                max-file: 5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
             driver: "json-file"
             options:
                 max-size: "50m"
-                max-file: 5
+                max-file: "5"
     db:
         image: dogi/rpi-couchdb
         expose:
@@ -26,4 +26,4 @@ services:
             driver: "json-file"
             options:
                 max-size: "50m"
-                max-file: 5
+                max-file: "5"


### PR DESCRIPTION
Fix for https://github.com/OpenAgInitiative/openag_brain_docker_rpi/issues/14.

Still need to test this on Raspberry Pi.