### PR TITLE
Add pfc2 compose file

### DIFF
--- a/personal_food_computer_v2.yaml
+++ b/personal_food_computer_v2.yaml
@@ -1,0 +1,31 @@
+# Start Docker containers with configuration for Personal Food Computer V2.
+# See http://wiki.openag.media.mit.edu/food_computer_2
+version: "2"
+services:
+    brain:
+        image: openag/rpi_brain
+        expose:
+            - 5000
+        devices:
+            - "/dev/ttyACM0:/dev/ttyACM0"
+        command: ~/catkin_ws/devel/env.sh rosrun openag_brain main -D http://db:5984 -A http://brain:5000 -f default personal_food_computer_v2 --screen
+        depends_on:
+            - db
+        restart: unless-stopped
+        logging:
+            driver: "json-file"
+            options:
+                max-size: "50m"
+                max-file: "5"
+    db:
+        image: dogi/rpi-couchdb
+        expose:
+            - 5984
+        ports:
+            - 5984:5984
+        restart: unless-stopped
+        logging:
+            driver: "json-file"
+            options:
+                max-size: "50m"
+                max-file: "5"


### PR DESCRIPTION
This PR creates a docker compose file which will load the Docker image with configuration for the Personal Food Computer.

Usage:

```bash
docker-compose -f personal_food_computer_v2.yaml
```